### PR TITLE
checking for undefined before destroying chart

### DIFF
--- a/src/VueC3.vue
+++ b/src/VueC3.vue
@@ -25,7 +25,9 @@
 
     methods: {
       destroyChart () {
-        this.$chart = this.$chart.destroy()
+        if (this.$chart) {
+          this.$chart = this.$chart.destroy()
+        }
       }
     },
 


### PR DESCRIPTION
I'm running into a situation where if a user navigates away from the page before the chart is finished building, it's throwing an error: Cannot read property 'destroy' of undefined.  Checking to make sure the chart exists before destroying fixed this.